### PR TITLE
Define the GraphQL schema for the API

### DIFF
--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -256,7 +256,7 @@ type Query {
     ): NFT
 
     """
-    Get a single NFT by its blockchain identifier.
+    Get a single NFT by its token ID.
     """
     nftByTokenID(
         """

--- a/schema/schema.md
+++ b/schema/schema.md
@@ -53,6 +53,26 @@ The query root of NFT.com GraphQL interface.
 			<td>ID of the NFT.</td>
 		</tr>
 		<tr>
+			<td colspan="2" valign="top"><strong>nftByTokenID</strong></td>
+			<td valign="top"><a href="#nft">NFT</a></td>
+			<td>Get a single NFT by its token ID.</td>
+		</tr>
+		<tr>
+			<td colspan="2" align="right" valign="top">chainID</td>
+			<td valign="top"><a href="#id">ID</a>!</td>
+			<td>Chain ID.</td>
+		</tr>
+		<tr>
+			<td colspan="2" align="right" valign="top">contract</td>
+			<td valign="top"><a href="#address">Address</a>!</td>
+			<td>ID of the smart contract.</td>
+		</tr>
+		<tr>
+			<td colspan="2" align="right" valign="top">tokenID</td>
+			<td valign="top"><a href="#string">String</a>!</td>
+			<td>Token ID of the NFT.</td>
+		</tr>
+		<tr>
 			<td colspan="2" valign="top"><strong>nfts</strong></td>
 			<td valign="top">[<a href="#nft">NFT</a>!]</td>
 			<td>Lookup NFTs based on specified criteria.</td>
@@ -68,7 +88,7 @@ The query root of NFT.com GraphQL interface.
 			<td>ID of the collection the NFT is part of.</td>
 		</tr>
 		<tr>
-			<td colspan="2" align="right" valign="top">rarity_min</td>
+			<td colspan="2" align="right" valign="top">rarityMin</td>
 			<td valign="top"><a href="#float">Float</a></td>
 			<td>Minimum rarity score.</td>
 		</tr>
@@ -86,6 +106,21 @@ The query root of NFT.com GraphQL interface.
 			<td colspan="2" align="right" valign="top">id</td>
 			<td valign="top"><a href="#id">ID</a>!</td>
 			<td>ID of the collection.</td>
+		</tr>
+		<tr>
+			<td colspan="2" valign="top"><strong>collectionByAddress</strong></td>
+			<td valign="top"><a href="#collection">Collection</a></td>
+			<td>Get a single collection by address.</td>
+		</tr>
+		<tr>
+			<td colspan="2" align="right" valign="top">chainID</td>
+			<td valign="top"><a href="#id">ID</a>!</td>
+			<td>Chain ID.</td>
+		</tr>
+		<tr>
+			<td colspan="2" align="right" valign="top">contract</td>
+			<td valign="top"><a href="#address">Address</a>!</td>
+			<td>Address of the smart contract.</td>
 		</tr>
 		<tr>
 			<td colspan="2" valign="top"><strong>collections</strong></td>
@@ -261,8 +296,8 @@ Marketplace represents a single NFT marketplace (e.g. Opensea, DefiKingdoms).
 			<td>NFT ID.</td>
 		</tr>
 		<tr>
-			<td colspan="2" valign="top"><strong>token_id</strong></td>
-			<td valign="top"><a href="#int">Int</a>!</td>
+			<td colspan="2" valign="top"><strong>tokenID</strong></td>
+			<td valign="top"><a href="#string">String</a>!</td>
 			<td>Token ID, as found on the blockchain.</td>
 		</tr>
 		<tr>
@@ -448,10 +483,6 @@ The `Float` scalar type represents signed double-precision fractional values as 
 ### ID
 
 The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID.
-
-### Int
-
-The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.
 
 ### String
 


### PR DESCRIPTION
This PR introduces the first draft of the GraphQL schema for the NFT.com API.

It maps the data types defined in the [Indexer PR #13](https://github.com/NFT-com/indexer/pull/13), and defines a few anticipated queries.

In the `schema.md` file is the generated documentation for the schema file. Perhaps in the future, this doc will be autogenerated.

Some of the stuff not yet done:
- paging - especially the event list will tend to be huge; I like the paging implementation where the inputs are `number of records` and `offset` as two parameters
- event types - currently the event type is a string; since events that come to mind are `mint`, `transfer`, `sell` and `burn`, they could potentially be pinned down as enums in the schema
- timestamps - all SQL tables have `created_at`, `updated_at` and `deleted_at` timestamps; if this is something that the frontend will need, in should be included in the GraphQL types
- some stuff was included though at the moment there's no _source of truth_ defined yet - sorting collections by market cap, daily volume, etc, as well as NFT value
- lookup of NFTs by traits - would like to know more about the intended queries for this; would it be a list of `{ name, value }` pairs, doing exact matching or partial match (for strings), range (for numbers) etc..