### PR TITLE
Fix field selection string for empty prefix

### DIFF
--- a/graph/query/query.go
+++ b/graph/query/query.go
@@ -49,7 +49,13 @@ func getNestedSelection(ctx *graphql.OperationContext, fields []graphql.Collecte
 	requested := make([]string, 0)
 
 	for _, field := range fields {
-		name := FieldPath(prefix, field.Name)
+		var name string
+		if prefix != "" {
+			name = FieldPath(prefix, field.Name)
+		} else {
+			name = FieldPath(field.Name)
+		}
+
 		requested = append(requested, name)
 
 		collected := graphql.CollectFields(ctx, field.Selections, nil)


### PR DESCRIPTION
Default selector for a top-level field is just the field name - e.g. `rarity`. Nested fields are prefixed by the parent name, e.g. `nfts.traits`.

This PR fixes the first scenario, where fields were prefixed with a `.` even if they were top-level fields.