### PR TITLE
Include stats in the GraphQL API

### DIFF
--- a/aggregate/api/price_history.go
+++ b/aggregate/api/price_history.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+
+	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 )
 
 // NFTPriceHistory handles the request for retrieving historic prices of an NFT.
@@ -42,5 +44,10 @@ func (a *API) NFTAveragePrice(ctx echo.Context) error {
 		return apiError(fmt.Errorf("could not retrieve NFT average price: %w", err))
 	}
 
-	return ctx.JSON(http.StatusOK, average)
+	response := datapoint.Value{
+		ID:    id,
+		Value: average.Average,
+	}
+
+	return ctx.JSON(http.StatusOK, response)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/99designs/gqlgen v0.17.3
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/labstack/echo/v4 v4.7.2
 	github.com/rs/zerolog v1.26.1
 	github.com/spf13/pflag v1.0.5
@@ -18,6 +19,7 @@ require (
 	github.com/agnivade/levenshtein v1.1.1 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,11 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/graph/aggregate/aggregate.go
+++ b/graph/aggregate/aggregate.go
@@ -1,0 +1,26 @@
+package aggregate
+
+import (
+	"net/url"
+
+	"github.com/rs/zerolog"
+)
+
+// Client interacts with the aggregation API.
+type Client struct {
+	log    zerolog.Logger
+	apiURL url.URL
+}
+
+// New creates a new aggregation API client.
+func New(log zerolog.Logger, apiURL url.URL) *Client {
+
+	c := Client{
+		log:    log,
+		apiURL: apiURL,
+	}
+
+	c.log.Debug().Str("api", apiURL.String()).Msg("creating aggregation API client")
+
+	return &c
+}

--- a/graph/aggregate/http/http.go
+++ b/graph/aggregate/http/http.go
@@ -1,0 +1,68 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	contentTypeJSON = "application/json"
+)
+
+// POST executes the HTTP request and unpacks the response. Request and responses are interpreted as JSON.
+func POST(address string, request interface{}, output interface{}) error {
+
+	// Prepare request.
+	data, err := json.Marshal(request)
+	if err != nil {
+		return fmt.Errorf("could not marshal request: %w", err)
+	}
+	reader := bytes.NewReader(data)
+
+	// Execute the request.
+	resp, err := http.Post(address, contentTypeJSON, reader)
+	if err != nil {
+		return fmt.Errorf("could not execute POST request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return unpackJSONResponse(resp, output)
+}
+
+// GET executes the HTTP request and unpacks the JSON response.
+func GET(address string, output interface{}) error {
+
+	resp, err := http.Get(address)
+	if err != nil {
+		return fmt.Errorf("could not execute GET request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return unpackJSONResponse(resp, output)
+}
+
+// UnpackJSONResponse processes the HTTP response and tries to unmarshal the returned JSON into the provided struct.
+func unpackJSONResponse(resp *http.Response, output interface{}) error {
+
+	// Read the response.
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("could not read response body: %w", err)
+	}
+
+	// Check the status code.
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request failed (code: %v, payload: %s)", resp.StatusCode, payload)
+	}
+
+	// Unpack the response data.
+	err = json.Unmarshal(payload, output)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal response (payload: %s): %w", payload, err)
+	}
+
+	return nil
+}

--- a/graph/aggregate/paths.go
+++ b/graph/aggregate/paths.go
@@ -1,0 +1,28 @@
+package aggregate
+
+import (
+	"net/url"
+)
+
+const (
+	nftBatchPriceEndpoint      = "/nft/batch/price"
+	fmtNFTAveragePriceEndpoint = "/nft/%v/average"
+
+	collectionBatchVolumeEndpoint    = "/collection/batch/volume"
+	collectionBatchMarketCapEndpoint = "/collection/batch/market_cap"
+	fmtCollectionSalesEndpoint       = "/collection/%s/sales"
+
+	fmtMarketplaceVolumeEndpoint    = "/marketplace/%s/volume"
+	fmtMarketplaceMarketCapEndpoint = "/marketplace/%s/market_cap"
+	fmtMarketplaceSalesEndpoint     = "/marketplace/%s/sales"
+	fmtMarketplaceUsersEndpoint     = "/marketplace/%s/users"
+)
+
+// createAddress creates the full URL for an HTTP request based on base URL and path.
+func createAddress(baseURL url.URL, path string) string {
+
+	out := baseURL
+	out.Path = path
+
+	return out.String()
+}

--- a/graph/aggregate/request.go
+++ b/graph/aggregate/request.go
@@ -1,0 +1,50 @@
+package aggregate
+
+import (
+	"fmt"
+
+	"github.com/NFT-com/analytics/aggregate/models/api"
+	"github.com/NFT-com/analytics/aggregate/models/datapoint"
+	"github.com/NFT-com/analytics/graph/aggregate/http"
+)
+
+// executeBatchRequest executes a generic POST request to retrieve stats for a list of IDS.
+func (c *Client) executeBatchRequest(ids []string, address string) (map[string]float64, error) {
+
+	// Create the batch price request.
+	req := api.BatchRequest{
+		IDs: ids,
+	}
+
+	// Execute the API request.
+	var res api.BatchResponse
+	err := http.POST(address, req, &res)
+	if err != nil {
+		return nil, fmt.Errorf("batch request failed: %w", err)
+	}
+
+	// Create the output.
+	out := make(map[string]float64)
+	for _, price := range res.Data {
+		out[price.ID] = price.Value
+	}
+
+	return out, nil
+}
+
+// executeRequest executes a generic GET request to retrieve stat for a single ID.
+func (c *Client) executeRequest(id string, address string) (float64, error) {
+
+	var res datapoint.Value
+	err := http.GET(address, &res)
+	if err != nil {
+		return 0, fmt.Errorf("request failed: %w", err)
+	}
+
+	// Verify that we have the correct record.
+	if res.ID != id {
+		return 0, fmt.Errorf("unexpected record returned (want: %v, have: %v): %w", id, res.ID, err)
+	}
+
+	return res.Value, nil
+}

--- a/graph/aggregate/stats.go
+++ b/graph/aggregate/stats.go
@@ -1,0 +1,92 @@
+package aggregate
+
+import (
+	"fmt"
+)
+
+// Prices retrieves the prices for the specified NFTs.
+func (c *Client) Prices(ids []string) (map[string]float64, error) {
+
+	c.log.Debug().Strs("ids", ids).Msg("requesting NFT prices")
+
+	address := createAddress(c.apiURL, nftBatchPriceEndpoint)
+	return c.executeBatchRequest(ids, address)
+}
+
+// AveragePrice retrieves the average price for the specified NFT.
+func (c *Client) AveragePrice(id string) (float64, error) {
+
+	c.log.Debug().Str("id", id).Msg("requesting NFT average price")
+
+	path := fmt.Sprintf(fmtNFTAveragePriceEndpoint, id)
+	address := createAddress(c.apiURL, path)
+	return c.executeRequest(id, address)
+}
+
+// CollectionVolumes retrieves the volumes for the specified collections.
+func (c *Client) CollectionVolumes(ids []string) (map[string]float64, error) {
+
+	c.log.Debug().Strs("ids", ids).Msg("requesting collection volumes")
+
+	address := createAddress(c.apiURL, collectionBatchVolumeEndpoint)
+	return c.executeBatchRequest(ids, address)
+}
+
+// CollectionMarketCaps retrieves the market caps for the specified collections.
+func (c *Client) CollectionMarketCaps(ids []string) (map[string]float64, error) {
+
+	c.log.Debug().Strs("ids", ids).Msg("requesting collection market caps")
+
+	address := createAddress(c.apiURL, collectionBatchMarketCapEndpoint)
+	return c.executeBatchRequest(ids, address)
+}
+
+// CollectionSales retrieves the sale count for the specified collection.
+func (c *Client) CollectionSales(id string) (float64, error) {
+
+	c.log.Debug().Str("id", id).Msg("requesting collection sale count")
+
+	path := fmt.Sprintf(fmtCollectionSalesEndpoint, id)
+	address := createAddress(c.apiURL, path)
+	return c.executeRequest(id, address)
+}
+
+// MarketplaceVolume retrieves the volume for the specified marketplace.
+func (c *Client) MarketplaceVolume(id string) (float64, error) {
+
+	c.log.Debug().Str("id", id).Msg("requesting marketplace volume")
+
+	path := fmt.Sprintf(fmtMarketplaceVolumeEndpoint, id)
+	address := createAddress(c.apiURL, path)
+	return c.executeRequest(id, address)
+}
+
+// MarketplaceMarketCap retrieves the market cap for the specified marketplace.
+func (c *Client) MarketplaceMarketCap(id string) (float64, error) {
+
+	c.log.Debug().Str("id", id).Msg("requesting marketplace market cap")
+
+	path := fmt.Sprintf(fmtMarketplaceMarketCapEndpoint, id)
+	address := createAddress(c.apiURL, path)
+	return c.executeRequest(id, address)
+}
+
+// MarketplaceSales retrieves the sale count for the specified marketplace.
+func (c *Client) MarketplaceSales(id string) (float64, error) {
+
+	c.log.Debug().Str("id", id).Msg("requesting marketplace sale count")
+
+	path := fmt.Sprintf(fmtMarketplaceSalesEndpoint, id)
+	address := createAddress(c.apiURL, path)
+	return c.executeRequest(id, address)
+}
+
+// MarketplaceUsers retrieves the user count for the specified marketplace.
+func (c *Client) MarketplaceUsers(id string) (float64, error) {
+
+	c.log.Debug().Str("id", id).Msg("requesting marketplace user count")
+
+	path := fmt.Sprintf(fmtMarketplaceUsersEndpoint, id)
+	address := createAddress(c.apiURL, path)
+	return c.executeRequest(id, address)
+}

--- a/graph/api/collection_details.go
+++ b/graph/api/collection_details.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/NFT-com/analytics/graph/api/internal/query"
+	"github.com/NFT-com/analytics/graph/models/api"
+)
+
+// expandCollectionDetails adds the NFT information to the collection object,
+// as well as the needed collection stats.
+func (s *Server) expandCollectionDetails(query *query.Collection, collection *api.Collection) error {
+
+	// Retrieve any statistics from the aggregation API.
+	err := s.expandCollectionStats(query, collection)
+	if err != nil {
+		// Continue even if stats could not be retrieved (e.g. API was unavailable).
+		s.log.Error().Err(err).Str("id", collection.ID).Msg("could not retrieve collection stats")
+	}
+
+	// If we don't need any NFT data, we're done.
+	if !query.NFTs {
+		return nil
+	}
+
+	err = s.expandCollectionNFTData(query, collection)
+	if err != nil {
+		return fmt.Errorf("could not get nft data: %w", err)
+	}
+
+	return nil
+}
+
+// expandCollectionStats retrieves the collection stats from the aggregation API.
+func (s *Server) expandCollectionStats(query *query.Collection, collection *api.Collection) error {
+
+	// Execute as much as possible, return the composite error in the end.
+	var multiErr error
+
+	// Get volume from the aggregation API.
+	if query.Volume {
+		volumes, err := s.aggregationAPI.CollectionVolumes([]string{collection.ID})
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get collection volume: %w", err))
+		}
+
+		collection.Volume = volumes[collection.ID]
+	}
+
+	// Get market cap from the aggregation API.
+	if query.MarketCap {
+		caps, err := s.aggregationAPI.CollectionMarketCaps([]string{collection.ID})
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get collection market cap: %w", err))
+		}
+
+		collection.MarketCap = caps[collection.ID]
+	}
+
+	// Get sale count from the aggregation API.
+	if query.Sales {
+		sales, err := s.aggregationAPI.CollectionSales(collection.ID)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get collection sales: %w", err))
+		}
+
+		collection.Sales = uint64(sales)
+	}
+
+	return multiErr
+}
+
+// expandCollectionNFTData is the workhorse function that will do all of the heavy lifting for
+// the collection queries. It fetches all NFTs from that collection
+// (similar to how dataloaders would), but also retrieves traits and deals with rarity calculation.
+// NOTE: This function modifies the provided collection in-place.
+func (s *Server) expandCollectionNFTData(query *query.Collection, collection *api.Collection) error {
+
+	// Retrieve the list of NFTs.
+	nfts, err := s.getCollectionNFTs(collection.ID)
+	if err != nil {
+		return fmt.Errorf("could not get NFTs in the collection: %w", err)
+	}
+
+	s.log.Debug().
+		Str("id", collection.ID).
+		Int("collection_size", len(nfts)).
+		Msg("retrieved list of nfts for collection")
+
+	collection.NFTs = nfts
+
+	s.log.Debug().
+		Bool("rarity", query.NFT.Rarity).
+		Bool("traits", query.NFT.Traits).
+		Bool("trait_rarity", query.NFT.TraitRarity).
+		Bool("owners", query.NFT.Owners).
+		Bool("price", query.NFT.Price).
+		Bool("average_price", query.NFT.AveragePrice).
+		Msg("NFT information requested")
+
+	// Retrieve owners if needed.
+	if query.NFT.Owners {
+		owners, err := s.storage.CollectionOwners(collection.ID)
+		if err != nil {
+			return fmt.Errorf("could not retrieve owners for the collection: %w", err)
+		}
+
+		// Set the owners for each of the NFTs.
+		for _, nft := range collection.NFTs {
+			nft.Owners = owners[nft.ID]
+		}
+	}
+
+	// If NFT prices are required, retrieve them now.
+	if query.NFT.Price || query.NFT.AveragePrice {
+
+		// TODO: Use batched request instead of looping through the NFT list.
+		// See https://github.com/NFT-com/analytics/issues/30
+
+		for _, nft := range collection.NFTs {
+			err = s.getNFTStats(&query.NFT, nft)
+			if err != nil {
+				// Continue even if stats could not be retrieved (e.g. API was unavailable).
+				s.log.Error().Err(err).Str("id", nft.ID).Msg("could not retrieve NFT price")
+			}
+		}
+	}
+
+	// If we do not need traits nor rarity, we're done.
+	if !query.NFT.Traits && !query.NFT.NeedRarity() {
+		return nil
+	}
+
+	// Fetch traits for this collection.
+	traits, err := s.getTraitsForCollection(collection.ID)
+	if err != nil {
+		return fmt.Errorf("could not get traits for the collection: %w", err)
+	}
+
+	// Link traits to corresponding NFT.
+	for _, nft := range collection.NFTs {
+		nft.Traits = traits[nft.ID]
+	}
+
+	// If don't need rarity information, we're done.
+	if !query.NFT.NeedRarity() {
+		return nil
+	}
+
+	// Crunch the data and determine trait frequency.
+	stats := traits.CalculateStats()
+
+	// Total number of NFTs in a collection, in relation to which we're calculating frequency.
+	total := len(collection.NFTs)
+
+	// Calculate trait rarity.
+	for _, nft := range collection.NFTs {
+
+		rarity, traitRarity := stats.CalculateRarity(uint(total), nft.Traits)
+
+		nft.Rarity = rarity
+		// Set this only if individual trait rarity is requested, since it includes
+		// traits not necessarily found in this NFT.
+		if query.NFT.TraitRarity {
+			nft.Traits = traitRarity
+		}
+	}
+
+	return nil
+}

--- a/graph/api/fields.go
+++ b/graph/api/fields.go
@@ -3,8 +3,17 @@ package api
 // These are some of the specific (expensive) fields for which we want to know
 // whether they were requested before retrieving.
 const (
-	fieldRarity = "rarity"
-	fieldTraits = "traits"
-	fieldOwners = "owners"
-	fieldNFTs   = "nfts"
+	// NFT fields.
+	fieldRarity       = "rarity"
+	fieldTraits       = "traits"
+	fieldOwners       = "owners"
+	fieldPrice        = "trading_price"
+	fieldAveragePrice = "average_price"
+
+	// Collection and marketplace fields.
+	fieldNFTs      = "nfts"
+	fieldVolume    = "volume"
+	fieldMarketCap = "market_cap"
+	fieldSales     = "sales"
+	fieldUsers     = "users"
 )

--- a/graph/api/internal/query/collection.go
+++ b/graph/api/internal/query/collection.go
@@ -1,0 +1,54 @@
+package query
+
+import (
+	"context"
+
+	"github.com/NFT-com/analytics/graph/query"
+)
+
+// CollectionFields describes the paths to the relevant fields in a collection query.
+type CollectionFields struct {
+	Volume    string
+	MarketCap string
+	Sales     string
+	NFTs      string
+	NFT       NFTFields
+}
+
+// Collection describes the collection query, specifically whether the GraphQL query requires
+// retrieving NFTs or fetching aggregated fields (stats) for the collection.
+type Collection struct {
+	Volume    bool
+	MarketCap bool
+	Sales     bool
+	NFTs      bool
+	NFT       NFT
+}
+
+// ParseCollectionQuery parses the GraphQL query according to the specified configuration.
+func ParseCollectionQuery(fields CollectionFields, ctx context.Context) *Collection {
+
+	selection := query.GetSelection(ctx)
+
+	query := Collection{
+		Volume:    selection.Has(fields.Volume),
+		MarketCap: selection.Has(fields.MarketCap),
+		Sales:     selection.Has(fields.Sales),
+		NFTs:      selection.Has(fields.NFTs),
+		NFT: NFT{
+			Rarity:       selection.Has(fields.NFT.Rarity),
+			Traits:       selection.Has(fields.NFT.Traits),
+			TraitRarity:  selection.Has(fields.NFT.TraitRarity),
+			Owners:       selection.Has(fields.NFT.Owners),
+			Price:        selection.Has(fields.NFT.Price),
+			AveragePrice: selection.Has(fields.NFT.AveragePrice),
+		},
+	}
+
+	return &query
+}
+
+// NeedStats returns true if any of the aggregated data is required.
+func (c *Collection) NeedStats() bool {
+	return c.Volume || c.MarketCap || c.Sales
+}

--- a/graph/api/internal/query/doc.go
+++ b/graph/api/internal/query/doc.go
@@ -1,0 +1,10 @@
+// Package query describes the GraphQL queries requesting Collection, Marketplace or NFT
+// data from the GraphQL server, in accordance with the GraphQL schema defined in
+// graph/schema/schema.graphql.
+//
+// Queries are parsed according to the provided configuration (path to each of the wanted fields)
+// and allow easy inspection to determine which fields were requested. Not all possible fields
+// for a type are modeled, but only those that carry expensive overhead in retrieving or calculating,
+// such as trait or rarity information, or any aggregated fields retrieved from the Aggregation API.
+
+package query

--- a/graph/api/internal/query/marketplace.go
+++ b/graph/api/internal/query/marketplace.go
@@ -1,0 +1,44 @@
+package query
+
+import (
+	"context"
+
+	"github.com/NFT-com/analytics/graph/query"
+)
+
+// MarketplaceFields describes the paths to the relevant fields in a marketplace query.
+type MarketplaceFields struct {
+	Volume    string
+	MarketCap string
+	Sales     string
+	Users     string
+}
+
+// Marketplace describes the marketplace query, specifically whether the GraphQL query requires
+// fetching aggregated fields (stats) for the marketplace.
+type Marketplace struct {
+	Volume    bool
+	MarketCap bool
+	Sales     bool
+	Users     bool
+}
+
+// ParseMarketplaceQuery parses the GraphQL query according to the specified configuration.
+func ParseMarketplaceQuery(fields MarketplaceFields, ctx context.Context) *Marketplace {
+
+	selection := query.GetSelection(ctx)
+
+	query := Marketplace{
+		Volume:    selection.Has(fields.Volume),
+		MarketCap: selection.Has(fields.MarketCap),
+		Sales:     selection.Has(fields.Sales),
+		Users:     selection.Has(fields.Users),
+	}
+
+	return &query
+}
+
+// NeedStats returns true if any of the aggregated data is required.
+func (q Marketplace) NeedStats() bool {
+	return q.Volume || q.MarketCap || q.Sales || q.Users
+}

--- a/graph/api/internal/query/nft.go
+++ b/graph/api/internal/query/nft.go
@@ -1,0 +1,51 @@
+package query
+
+import (
+	"context"
+
+	"github.com/NFT-com/analytics/graph/query"
+)
+
+// NFTFields describes the paths to the relevant fields in an NFT query.
+type NFTFields struct {
+	Traits       string
+	TraitRarity  string
+	Rarity       string
+	Owners       string
+	Price        string
+	AveragePrice string
+}
+
+// NFT is used to describe the NFT detail query, namely whether the GraphQL query
+// requires fetching of expensive fields such as traits, rarity information or
+// aggregated data (stats) for the NFT.
+type NFT struct {
+	Traits       bool
+	TraitRarity  bool
+	Rarity       bool
+	Owners       bool
+	Price        bool
+	AveragePrice bool
+}
+
+// ParseNFTQuery parses the GraphQL query according to the specified configuration.
+func ParseNFTQuery(fields NFTFields, ctx context.Context) *NFT {
+
+	selection := query.GetSelection(ctx)
+
+	query := NFT{
+		Traits:       selection.Has(fields.Traits),
+		TraitRarity:  selection.Has(fields.TraitRarity),
+		Owners:       selection.Has(fields.Owners),
+		Rarity:       selection.Has(fields.Rarity),
+		Price:        selection.Has(fields.Price),
+		AveragePrice: selection.Has(fields.AveragePrice),
+	}
+
+	return &query
+}
+
+// NeedRarity returns true if either overall rarity or trait rarity is needed.
+func (q NFT) NeedRarity() bool {
+	return q.TraitRarity || q.Rarity
+}

--- a/graph/api/marketplace_stats.go
+++ b/graph/api/marketplace_stats.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/NFT-com/analytics/graph/api/internal/query"
+	"github.com/NFT-com/analytics/graph/models/api"
+)
+
+func (s *Server) expandMarketplaceStats(query *query.Marketplace, marketplace *api.Marketplace) error {
+
+	// Execute as much as possible, return the composite error in the end.
+	var multiErr error
+
+	// Get volume from the aggregation API.
+	if query.Volume {
+		volume, err := s.aggregationAPI.MarketplaceVolume(marketplace.ID)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace volume: %w", err))
+		}
+
+		marketplace.Volume = volume
+	}
+
+	// Get market cap from the aggregation API.
+	if query.MarketCap {
+		cap, err := s.aggregationAPI.MarketplaceMarketCap(marketplace.ID)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace market cap: %w", err))
+		}
+
+		marketplace.MarketCap = cap
+	}
+
+	// Get sale count from the aggregation API.
+	if query.Sales {
+		sales, err := s.aggregationAPI.MarketplaceSales(marketplace.ID)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace sales: %w", err))
+		}
+
+		marketplace.Sales = uint64(sales)
+	}
+
+	// Get user count from the aggregation API.
+	if query.Users {
+		users, err := s.aggregationAPI.MarketplaceUsers(marketplace.ID)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace users: %w", err))
+		}
+
+		marketplace.Users = uint64(users)
+	}
+
+	return multiErr
+}

--- a/graph/api/nft_details.go
+++ b/graph/api/nft_details.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/NFT-com/analytics/graph/api/internal/query"
+	"github.com/NFT-com/analytics/graph/models/api"
+)
+
+func (s *Server) expandNFTDetails(query *query.NFT, nft *api.NFT) error {
+
+	// Retrieve owner if it was requested.
+	if query.Owners {
+		owners, err := s.storage.NFTOwners(nft.ID)
+		if err != nil {
+			return fmt.Errorf("could not retrieve owners for the NFT: %w", err)
+		}
+		nft.Owners = owners
+	}
+
+	// Get NFT stats from the aggregation API.
+	err := s.getNFTStats(query, nft)
+	if err != nil {
+		// Continue even if stats could not be retrieved (e.g. API was unavailable).
+		s.log.Error().
+			Err(err).
+			Str("id", nft.ID).
+			Msg("could not retrieve NFT stats")
+	}
+
+	// Get trait data and, if required, calculate rarity as well.
+	err = s.getNFTRarityAndTraitData(query, nft)
+	if err != nil {
+		return fmt.Errorf("could not retrieve rarity/trait information: %w", err)
+	}
+
+	return nil
+}
+
+// getNFTRarityAndTraitData retrieves the NFT rarity and/or trait information.
+func (s *Server) getNFTRarityAndTraitData(query *query.NFT, nft *api.NFT) error {
+
+	// If we do not need traits nor rarity, we're done.
+	if !query.Traits && !query.NeedRarity() {
+		return nil
+	}
+
+	// If we do not need rarity, just fetch the traits for this NFT.
+	if !query.NeedRarity() {
+		traits, err := s.storage.NFTTraits(nft.ID)
+		if err != nil {
+			s.logError(err).Str("id", nft.ID).Msg("could not retrieve traits")
+			return errRetrieveTraitsFailed
+		}
+
+		nft.Traits = traits
+		return nil
+	}
+
+	// Get traits and calculate rarity.
+	traits, err := s.getTraitsForCollection(nft.Collection)
+	if err != nil {
+		return errRetrieveTraitsFailed
+	}
+	nft.Traits = traits[nft.ID]
+
+	// Get the size of this collection.
+	size, err := s.storage.CollectionSize(nft.Collection)
+	if err != nil {
+		s.logError(err).Str("collection", nft.Collection).Msg("could not retrieve collection size")
+		return errRetrieveTraitsFailed
+	}
+
+	stats := traits.CalculateStats()
+	rarity, traitRarity := stats.CalculateRarity(size, nft.Traits)
+
+	nft.Rarity = rarity
+
+	// Returned traits include traits missing for this NFT.
+	// Only set them if individual trait rarity is requested.
+	if query.TraitRarity {
+		nft.Traits = traitRarity
+	}
+
+	return nil
+}

--- a/graph/api/prices.go
+++ b/graph/api/prices.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/NFT-com/analytics/graph/api/internal/query"
+	"github.com/NFT-com/analytics/graph/models/api"
+)
+
+func (s *Server) getNFTStats(query *query.NFT, nft *api.NFT) error {
+
+	var multiErr error
+
+	// Retrieve NFT price from the aggregation API.
+	if query.Price {
+		prices, err := s.aggregationAPI.Prices([]string{nft.ID})
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not retrieve price for NFT: %w", err))
+		}
+
+		nft.TradingPrice = prices[nft.ID]
+	}
+
+	// Retrieve NFT average price from the aggregation API.
+	if query.AveragePrice {
+		average, err := s.aggregationAPI.AveragePrice(nft.ID)
+		if err != nil {
+			multiErr = multierror.Append(multiErr, fmt.Errorf("could not retrieve average price for NFT: %w", err))
+		}
+
+		nft.AveragePrice = average
+	}
+
+	return multiErr
+}

--- a/graph/api/schema_resolvers.go
+++ b/graph/api/schema_resolvers.go
@@ -20,7 +20,7 @@ func (r *collectionServer) Network(ctx context.Context, obj *api.Collection) (*a
 func (r *collectionServer) Marketplaces(ctx context.Context, obj *api.Collection) ([]*api.Marketplace, error) {
 	// Marketplace handles expanding the list of Marketplaces within a Collection object.
 
-	return r.Server.collectionsListings(obj.ID)
+	return r.Server.collectionsListings(ctx, obj.ID)
 }
 
 func (r *marketplaceServer) Networks(ctx context.Context, obj *api.Marketplace) ([]*api.Network, error) {
@@ -44,7 +44,7 @@ func (r *nFTServer) Collection(ctx context.Context, obj *api.NFT) (*api.Collecti
 func (r *networkServer) Marketplaces(ctx context.Context, obj *api.Network) ([]*api.Marketplace, error) {
 	// Marketplaces handles expanding the list of Marketplaces within a Network object.
 
-	return r.Server.marketplacesByNetwork(obj.ID)
+	return r.Server.marketplacesByNetwork(ctx, obj.ID)
 }
 
 func (r *networkServer) Collections(ctx context.Context, obj *api.Network) ([]*api.Collection, error) {
@@ -80,7 +80,8 @@ func (r *queryServer) NftByTokenID(ctx context.Context, networkID string, contra
 func (r *queryServer) Nfts(ctx context.Context, owner *string, collection *string, rarityMax *float64, orderBy *api.NFTOrder) ([]*api.NFT, error) {
 	// Nfts implements the `nfts` GraphQL query.
 
-	// FIXME: remove the validation of the sorting mode when all modes become supported
+	// TODO: Implement remaining sorting modes.
+	// See https://github.com/NFT-com/analytics/issues/31
 	switch orderBy.Field {
 
 	case api.NFTOrderFieldValue, api.NFTOrderFieldRarity:
@@ -110,9 +111,10 @@ func (r *queryServer) CollectionByAddress(ctx context.Context, networkID string,
 func (r *queryServer) Collections(ctx context.Context, networkID *string, orderBy *api.CollectionOrder) ([]*api.Collection, error) {
 	// Collections implements the `collections` GraphQL query.
 
+	// TODO: Implement remaining sorting modes.
+	// See https://github.com/NFT-com/analytics/issues/31
 	switch orderBy.Field {
 
-	// FIXME: remove when all modes become supported
 	default:
 		return nil, errors.New("TBD: sorting mode not supported")
 

--- a/graph/api/selection.go
+++ b/graph/api/selection.go
@@ -3,51 +3,55 @@ package api
 import (
 	"context"
 
-	"github.com/NFT-com/analytics/graph/query"
+	"github.com/NFT-com/analytics/graph/api/internal/query"
+	gql "github.com/NFT-com/analytics/graph/query"
 )
 
-type nftQueryConfig struct {
-	traitPath       string
-	traitRarityPath string
-	rarityPath      string
-	ownersPath      string
-}
+// parseNFTQuery parses the GraphQL NFT query.
+func parseNFTQuery(ctx context.Context) *query.NFT {
 
-// nftQuery is used to describe the NFT detail query, namely whether the GraphQL query
-// requires fetching of NFT traits, calculating trait rarity or overall NFT rarity.
-type nftQuery struct {
-	traits      bool
-	traitRarity bool
-	nftRarity   bool
-	owners      bool
-}
-
-// parseNFTQuery parses the GraphQL query with the default configuration.
-func parseNFTQuery(ctx context.Context) *nftQuery {
-	cfg := nftQueryConfig{
-		traitPath:       query.FieldPath(fieldTraits),
-		traitRarityPath: query.FieldPath(fieldTraits, fieldRarity),
-		rarityPath:      query.FieldPath(fieldRarity),
-		ownersPath:      query.FieldPath(fieldOwners),
-	}
-	return parseNFTQueryWithConfig(cfg, ctx)
-}
-
-// parseNFTQueryWithConfig parses the GraphQL query according to the specified configuration.
-func parseNFTQueryWithConfig(cfg nftQueryConfig, ctx context.Context) *nftQuery {
-
-	selection := query.GetSelection(ctx)
-
-	query := nftQuery{
-		traits:      selection.Has(cfg.traitPath),
-		traitRarity: selection.Has(cfg.traitRarityPath),
-		nftRarity:   selection.Has(cfg.rarityPath),
-		owners:      selection.Has(cfg.ownersPath),
+	paths := query.NFTFields{
+		Traits:       gql.FieldPath(fieldTraits),
+		TraitRarity:  gql.FieldPath(fieldTraits, fieldRarity),
+		Rarity:       gql.FieldPath(fieldRarity),
+		Owners:       gql.FieldPath(fieldOwners),
+		Price:        gql.FieldPath(fieldPrice),
+		AveragePrice: gql.FieldPath(fieldAveragePrice),
 	}
 
-	return &query
+	return query.ParseNFTQuery(paths, ctx)
 }
 
-func (q nftQuery) needRarity() bool {
-	return q.traitRarity || q.nftRarity
+// parseCollectionQuery parses the GraphQL Collection query.
+func parseCollectionQuery(ctx context.Context) *query.Collection {
+
+	paths := query.CollectionFields{
+		Volume:    gql.FieldPath(fieldVolume),
+		MarketCap: gql.FieldPath(fieldMarketCap),
+		Sales:     gql.FieldPath(fieldSales),
+		NFTs:      gql.FieldPath(fieldNFTs),
+		NFT: query.NFTFields{
+			Traits:       gql.FieldPath(fieldNFTs, fieldTraits),
+			TraitRarity:  gql.FieldPath(fieldNFTs, fieldTraits, fieldRarity),
+			Rarity:       gql.FieldPath(fieldNFTs, fieldRarity),
+			Owners:       gql.FieldPath(fieldNFTs, fieldOwners),
+			Price:        gql.FieldPath(fieldNFTs, fieldPrice),
+			AveragePrice: gql.FieldPath(fieldNFTs, fieldAveragePrice),
+		},
+	}
+
+	return query.ParseCollectionQuery(paths, ctx)
+}
+
+// parseMarketplaceQuery parses the GraphQL Marketplace query.
+func parseMarketplaceQuery(ctx context.Context) *query.Marketplace {
+
+	paths := query.MarketplaceFields{
+		Volume:    gql.FieldPath(fieldVolume),
+		MarketCap: gql.FieldPath(fieldMarketCap),
+		Sales:     gql.FieldPath(fieldSales),
+		Users:     gql.FieldPath(fieldUsers),
+	}
+
+	return query.ParseMarketplaceQuery(paths, ctx)
 }

--- a/graph/api/server.go
+++ b/graph/api/server.go
@@ -6,14 +6,15 @@ import (
 
 // Server is an API server.
 type Server struct {
-	log     zerolog.Logger
-	storage Storage
+	log            zerolog.Logger
+	storage        Storage
+	aggregationAPI Stats
 
 	searchLimit uint
 }
 
 // NewServer creates a new API server.
-func NewServer(log zerolog.Logger, storage Storage, opts ...OptionFunc) *Server {
+func NewServer(log zerolog.Logger, storage Storage, aggregationAPI Stats, opts ...OptionFunc) *Server {
 
 	cfg := defaultConfig
 	for _, opt := range opts {
@@ -21,9 +22,10 @@ func NewServer(log zerolog.Logger, storage Storage, opts ...OptionFunc) *Server 
 	}
 
 	server := Server{
-		log:         log,
-		storage:     storage,
-		searchLimit: cfg.SearchLimit,
+		log:            log,
+		storage:        storage,
+		aggregationAPI: aggregationAPI,
+		searchLimit:    cfg.SearchLimit,
 	}
 
 	return &server

--- a/graph/api/stats.go
+++ b/graph/api/stats.go
@@ -1,0 +1,18 @@
+package api
+
+// TODO: Add batch requests for all stats.
+// See https://github.com/NFT-com/analytics/issues/39.
+
+type Stats interface {
+	Prices(nftIDs []string) (map[string]float64, error)
+	AveragePrice(nftID string) (float64, error)
+
+	CollectionVolumes(collectionIDs []string) (map[string]float64, error)
+	CollectionMarketCaps(collectionIDs []string) (map[string]float64, error)
+	CollectionSales(collectionID string) (float64, error)
+
+	MarketplaceVolume(marketplaceID string) (float64, error)
+	MarketplaceMarketCap(marketplaceID string) (float64, error)
+	MarketplaceSales(marketplaceID string) (float64, error)
+	MarketplaceUsers(marketplaceID string) (float64, error)
+}

--- a/graph/generated/generated.go
+++ b/graph/generated/generated.go
@@ -51,10 +51,13 @@ type ComplexityRoot struct {
 		Description  func(childComplexity int) int
 		ID           func(childComplexity int) int
 		ImageURL     func(childComplexity int) int
+		MarketCap    func(childComplexity int) int
 		Marketplaces func(childComplexity int) int
 		NFTs         func(childComplexity int) int
 		Name         func(childComplexity int) int
 		Network      func(childComplexity int) int
+		Sales        func(childComplexity int) int
+		Volume       func(childComplexity int) int
 		Website      func(childComplexity int) int
 	}
 
@@ -62,22 +65,28 @@ type ComplexityRoot struct {
 		Collections func(childComplexity int) int
 		Description func(childComplexity int) int
 		ID          func(childComplexity int) int
+		MarketCap   func(childComplexity int) int
 		Name        func(childComplexity int) int
 		Networks    func(childComplexity int) int
+		Sales       func(childComplexity int) int
+		Users       func(childComplexity int) int
+		Volume      func(childComplexity int) int
 		Website     func(childComplexity int) int
 	}
 
 	NFT struct {
-		Collection  func(childComplexity int) int
-		Description func(childComplexity int) int
-		ID          func(childComplexity int) int
-		ImageURL    func(childComplexity int) int
-		Name        func(childComplexity int) int
-		Owners      func(childComplexity int) int
-		Rarity      func(childComplexity int) int
-		TokenID     func(childComplexity int) int
-		Traits      func(childComplexity int) int
-		URI         func(childComplexity int) int
+		AveragePrice func(childComplexity int) int
+		Collection   func(childComplexity int) int
+		Description  func(childComplexity int) int
+		ID           func(childComplexity int) int
+		ImageURL     func(childComplexity int) int
+		Name         func(childComplexity int) int
+		Owners       func(childComplexity int) int
+		Rarity       func(childComplexity int) int
+		TokenID      func(childComplexity int) int
+		TradingPrice func(childComplexity int) int
+		Traits       func(childComplexity int) int
+		URI          func(childComplexity int) int
 	}
 
 	Network struct {
@@ -175,6 +184,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Collection.ImageURL(childComplexity), true
 
+	case "Collection.market_cap":
+		if e.complexity.Collection.MarketCap == nil {
+			break
+		}
+
+		return e.complexity.Collection.MarketCap(childComplexity), true
+
 	case "Collection.marketplaces":
 		if e.complexity.Collection.Marketplaces == nil {
 			break
@@ -202,6 +218,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Collection.Network(childComplexity), true
+
+	case "Collection.sales":
+		if e.complexity.Collection.Sales == nil {
+			break
+		}
+
+		return e.complexity.Collection.Sales(childComplexity), true
+
+	case "Collection.volume":
+		if e.complexity.Collection.Volume == nil {
+			break
+		}
+
+		return e.complexity.Collection.Volume(childComplexity), true
 
 	case "Collection.website":
 		if e.complexity.Collection.Website == nil {
@@ -231,6 +261,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Marketplace.ID(childComplexity), true
 
+	case "Marketplace.market_cap":
+		if e.complexity.Marketplace.MarketCap == nil {
+			break
+		}
+
+		return e.complexity.Marketplace.MarketCap(childComplexity), true
+
 	case "Marketplace.name":
 		if e.complexity.Marketplace.Name == nil {
 			break
@@ -245,12 +282,40 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Marketplace.Networks(childComplexity), true
 
+	case "Marketplace.sales":
+		if e.complexity.Marketplace.Sales == nil {
+			break
+		}
+
+		return e.complexity.Marketplace.Sales(childComplexity), true
+
+	case "Marketplace.users":
+		if e.complexity.Marketplace.Users == nil {
+			break
+		}
+
+		return e.complexity.Marketplace.Users(childComplexity), true
+
+	case "Marketplace.volume":
+		if e.complexity.Marketplace.Volume == nil {
+			break
+		}
+
+		return e.complexity.Marketplace.Volume(childComplexity), true
+
 	case "Marketplace.website":
 		if e.complexity.Marketplace.Website == nil {
 			break
 		}
 
 		return e.complexity.Marketplace.Website(childComplexity), true
+
+	case "NFT.average_price":
+		if e.complexity.NFT.AveragePrice == nil {
+			break
+		}
+
+		return e.complexity.NFT.AveragePrice(childComplexity), true
 
 	case "NFT.collection":
 		if e.complexity.NFT.Collection == nil {
@@ -307,6 +372,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.NFT.TokenID(childComplexity), true
+
+	case "NFT.trading_price":
+		if e.complexity.NFT.TradingPrice == nil {
+			break
+		}
+
+		return e.complexity.NFT.TradingPrice(childComplexity), true
 
 	case "NFT.traits":
 		if e.complexity.NFT.Traits == nil {
@@ -601,6 +673,26 @@ type Marketplace {
     website: String
 
     """
+    Trading volume on this marketplace.
+    """
+    volume: Float!
+
+    """
+    Market cap of this marketplace.
+    """
+    market_cap: Float!
+
+    """
+    Number of sales on this marketplace.
+    """
+    sales: Int!
+
+    """
+    Number of users on this marketplace.
+    """
+    users: Int!
+
+    """
     Networks the marketplace operates on.
     """
     networks: [Network!]!
@@ -644,6 +736,21 @@ type Collection {
     URL of an image for the collection.
     """
     image_url: String
+
+    """
+    Trading volume of this collection.
+    """
+    volume: Float!
+
+    """
+    Market cap of this collection.
+    """
+    market_cap: Float!
+
+    """
+    Number of sales in this collection.
+    """
+    sales: Int!
 
     """
     Network on which collection resides on.
@@ -696,14 +803,14 @@ enum CollectionOrderField {
     TOTAL_VOLUME
 
     """
-    Order by biggest gains.
+    Order by market cap gain.
     """
-    BIGGEST_GAINS
+    MARKET_CAP_GAIN
 
     """
-    Order by biggest losses.
+    Order by number of sales.
     """
-    BIGGEST_LOSSES
+    SALES
 
     """
     Order by daily volume.
@@ -754,6 +861,16 @@ type NFT {
     Rarity score for the NFT.
     """
     rarity: Float!
+
+    """
+    Trading price for this NFT.
+    """
+    trading_price: Float!
+
+    """
+    All time average-price for this NFT.
+    """
+    average_price: Float!
 
     """
     Traits contains a list of attributes of the NFT.
@@ -1370,6 +1487,111 @@ func (ec *executionContext) _Collection_image_url(ctx context.Context, field gra
 	return ec.marshalOString2string(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _Collection_volume(ctx context.Context, field graphql.CollectedField, obj *api.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Volume, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_market_cap(ctx context.Context, field graphql.CollectedField, obj *api.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MarketCap, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Collection_sales(ctx context.Context, field graphql.CollectedField, obj *api.Collection) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Collection",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Sales, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNInt2uint64(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _Collection_network(ctx context.Context, field graphql.CollectedField, obj *api.Collection) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1604,6 +1826,146 @@ func (ec *executionContext) _Marketplace_website(ctx context.Context, field grap
 	res := resTmp.(string)
 	fc.Result = res
 	return ec.marshalOString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Marketplace_volume(ctx context.Context, field graphql.CollectedField, obj *api.Marketplace) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Marketplace",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Volume, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Marketplace_market_cap(ctx context.Context, field graphql.CollectedField, obj *api.Marketplace) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Marketplace",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.MarketCap, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Marketplace_sales(ctx context.Context, field graphql.CollectedField, obj *api.Marketplace) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Marketplace",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Sales, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNInt2uint64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Marketplace_users(ctx context.Context, field graphql.CollectedField, obj *api.Marketplace) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "Marketplace",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Users, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(uint64)
+	fc.Result = res
+	return ec.marshalNInt2uint64(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Marketplace_networks(ctx context.Context, field graphql.CollectedField, obj *api.Marketplace) (ret graphql.Marshaler) {
@@ -1925,6 +2287,76 @@ func (ec *executionContext) _NFT_rarity(ctx context.Context, field graphql.Colle
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
 		return obj.Rarity, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NFT_trading_price(ctx context.Context, field graphql.CollectedField, obj *api.NFT) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NFT",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.TradingPrice, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _NFT_average_price(ctx context.Context, field graphql.CollectedField, obj *api.NFT) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:     "NFT",
+		Field:      field,
+		Args:       nil,
+		IsMethod:   false,
+		IsResolver: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AveragePrice, nil
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -3978,6 +4410,36 @@ func (ec *executionContext) _Collection(ctx context.Context, sel ast.SelectionSe
 
 			out.Values[i] = innerFunc(ctx)
 
+		case "volume":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_volume(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "market_cap":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_market_cap(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "sales":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Collection_sales(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "network":
 			field := field
 
@@ -4080,6 +4542,46 @@ func (ec *executionContext) _Marketplace(ctx context.Context, sel ast.SelectionS
 
 			out.Values[i] = innerFunc(ctx)
 
+		case "volume":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Marketplace_volume(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "market_cap":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Marketplace_market_cap(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "sales":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Marketplace_sales(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "users":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Marketplace_users(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "networks":
 			field := field
 
@@ -4199,6 +4701,26 @@ func (ec *executionContext) _NFT(ctx context.Context, sel ast.SelectionSet, obj 
 		case "rarity":
 			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._NFT_rarity(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "trading_price":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._NFT_trading_price(ctx, field, obj)
+			}
+
+			out.Values[i] = innerFunc(ctx)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
+		case "average_price":
+			innerFunc := func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._NFT_average_price(ctx, field, obj)
 			}
 
 			out.Values[i] = innerFunc(ctx)
@@ -5083,6 +5605,21 @@ func (ec *executionContext) unmarshalNID2string(ctx context.Context, v interface
 
 func (ec *executionContext) marshalNID2string(ctx context.Context, sel ast.SelectionSet, v string) graphql.Marshaler {
 	res := graphql.MarshalID(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+	}
+	return res
+}
+
+func (ec *executionContext) unmarshalNInt2uint64(ctx context.Context, v interface{}) (uint64, error) {
+	res, err := graphql.UnmarshalUint64(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2uint64(ctx context.Context, sel ast.SelectionSet, v uint64) graphql.Marshaler {
+	res := graphql.MarshalUint64(v)
 	if res == graphql.Null {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			ec.Errorf(ctx, "must not be null")

--- a/graph/gqlgen.yml
+++ b/graph/gqlgen.yml
@@ -43,6 +43,7 @@ models:
       - github.com/99designs/gqlgen/graphql.Int
       - github.com/99designs/gqlgen/graphql.Int64
       - github.com/99designs/gqlgen/graphql.Int32
+      - github.com/99designs/gqlgen/graphql.Uint64
   NFT:
     model:
       - "github.com/NFT-com/analytics/graph/models/api.NFT"

--- a/graph/models/api/generated.go
+++ b/graph/models/api/generated.go
@@ -34,10 +34,10 @@ const (
 	CollectionOrderFieldMarketCap CollectionOrderField = "MARKET_CAP"
 	// Order by total volume.
 	CollectionOrderFieldTotalVolume CollectionOrderField = "TOTAL_VOLUME"
-	// Order by biggest gains.
-	CollectionOrderFieldBiggestGains CollectionOrderField = "BIGGEST_GAINS"
-	// Order by biggest losses.
-	CollectionOrderFieldBiggestLosses CollectionOrderField = "BIGGEST_LOSSES"
+	// Order by market cap gain.
+	CollectionOrderFieldMarketCapGain CollectionOrderField = "MARKET_CAP_GAIN"
+	// Order by number of sales.
+	CollectionOrderFieldSales CollectionOrderField = "SALES"
 	// Order by daily volume.
 	CollectionOrderFieldDailyVolume CollectionOrderField = "DAILY_VOLUME"
 )
@@ -46,14 +46,14 @@ var AllCollectionOrderField = []CollectionOrderField{
 	CollectionOrderFieldCreationTime,
 	CollectionOrderFieldMarketCap,
 	CollectionOrderFieldTotalVolume,
-	CollectionOrderFieldBiggestGains,
-	CollectionOrderFieldBiggestLosses,
+	CollectionOrderFieldMarketCapGain,
+	CollectionOrderFieldSales,
 	CollectionOrderFieldDailyVolume,
 }
 
 func (e CollectionOrderField) IsValid() bool {
 	switch e {
-	case CollectionOrderFieldCreationTime, CollectionOrderFieldMarketCap, CollectionOrderFieldTotalVolume, CollectionOrderFieldBiggestGains, CollectionOrderFieldBiggestLosses, CollectionOrderFieldDailyVolume:
+	case CollectionOrderFieldCreationTime, CollectionOrderFieldMarketCap, CollectionOrderFieldTotalVolume, CollectionOrderFieldMarketCapGain, CollectionOrderFieldSales, CollectionOrderFieldDailyVolume:
 		return true
 	}
 	return false

--- a/graph/models/api/model.go
+++ b/graph/models/api/model.go
@@ -10,36 +10,45 @@ type Network struct {
 
 // Collection represents a group of NFTs that share the same smart contract.
 type Collection struct {
-	ID          string `gorm:"column:id" json:"id"`
-	Name        string `gorm:"column:name" json:"name"`
-	Description string `gorm:"column:description" json:"description"`
-	Address     string `gorm:"column:contract_address" json:"address"`
-	Website     string `gorm:"column:website" json:"website"`
-	ImageURL    string `gorm:"column:image_url" json:"image_url"`
-	NFTs        []*NFT `gorm:"-" json:"nfts"`
-	NetworkID   string `gorm:"column:network_id" json:"-"`
+	ID          string  `gorm:"column:id" json:"id"`
+	Name        string  `gorm:"column:name" json:"name"`
+	Description string  `gorm:"column:description" json:"description"`
+	Address     string  `gorm:"column:contract_address" json:"address"`
+	Website     string  `gorm:"column:website" json:"website"`
+	ImageURL    string  `gorm:"column:image_url" json:"image_url"`
+	NFTs        []*NFT  `gorm:"-" json:"nfts"`
+	NetworkID   string  `gorm:"column:network_id" json:"-"`
+	Volume      float64 `gorm:"-" json:"volume"`
+	MarketCap   float64 `gorm:"-" json:"market_cap"`
+	Sales       uint64  `gorm:"-" json:"sales"`
 }
 
 // Marketplace represents a single NFT marketplace (e.g. Opensea, DefiKingdoms).
 type Marketplace struct {
-	ID          string `gorm:"column:id" json:"id"`
-	Name        string `gorm:"column:name" json:"name"`
-	Description string `gorm:"column:description" json:"description"`
-	Website     string `gorm:"column:website" json:"website"`
+	ID          string  `gorm:"column:id" json:"id"`
+	Name        string  `gorm:"column:name" json:"name"`
+	Description string  `gorm:"column:description" json:"description"`
+	Website     string  `gorm:"column:website" json:"website"`
+	Volume      float64 `gorm:"-" json:"volume"`
+	MarketCap   float64 `gorm:"-" json:"market_cap"`
+	Sales       uint64  `gorm:"-" json:"sales"`
+	Users       uint64  `gorm:"-" json:"users"`
 }
 
 // NFT represents a single Non-Fungible Token.
 type NFT struct {
-	ID          string   `gorm:"column:id" json:"id"`
-	Name        string   `gorm:"column:name" json:"name,omitempty"`
-	ImageURL    string   `gorm:"column:image" json:"image_url,omitempty"`
-	URI         string   `gorm:"column:uri" json:"uri,omitempty"`
-	Description string   `gorm:"column:description" json:"description,omitempty"`
-	TokenID     string   `gorm:"column:token_id" json:"token_id"`
-	Collection  string   `gorm:"column:collection_id" json:"-"`
-	Owners      []string `gorm:"-" json:"owners,omitempty"`
-	Traits      []Trait  `gorm:"-" json:"traits,omitempty"`
-	Rarity      float64  `gorm:"-" json:"rarity,omitempty"`
+	ID           string   `gorm:"column:id" json:"id"`
+	Name         string   `gorm:"column:name" json:"name,omitempty"`
+	ImageURL     string   `gorm:"column:image" json:"image_url,omitempty"`
+	URI          string   `gorm:"column:uri" json:"uri,omitempty"`
+	Description  string   `gorm:"column:description" json:"description,omitempty"`
+	TokenID      string   `gorm:"column:token_id" json:"token_id"`
+	Collection   string   `gorm:"column:collection_id" json:"-"`
+	Owners       []string `gorm:"-" json:"owners,omitempty"`
+	Traits       []Trait  `gorm:"-" json:"traits,omitempty"`
+	Rarity       float64  `gorm:"-" json:"rarity,omitempty"`
+	TradingPrice float64  `gorm:"-" json:"trading_price,omitempty"`
+	AveragePrice float64  `gorm:"-" json:"average_price,omitempty"`
 }
 
 // Trait represents a single NFT trait.

--- a/graph/schema/schema.graphql
+++ b/graph/schema/schema.graphql
@@ -80,6 +80,26 @@ type Marketplace {
     website: String
 
     """
+    Trading volume on this marketplace.
+    """
+    volume: Float!
+
+    """
+    Market cap of this marketplace.
+    """
+    market_cap: Float!
+
+    """
+    Number of sales on this marketplace.
+    """
+    sales: Int!
+
+    """
+    Number of users on this marketplace.
+    """
+    users: Int!
+
+    """
     Networks the marketplace operates on.
     """
     networks: [Network!]!
@@ -123,6 +143,21 @@ type Collection {
     URL of an image for the collection.
     """
     image_url: String
+
+    """
+    Trading volume of this collection.
+    """
+    volume: Float!
+
+    """
+    Market cap of this collection.
+    """
+    market_cap: Float!
+
+    """
+    Number of sales in this collection.
+    """
+    sales: Int!
 
     """
     Network on which collection resides on.
@@ -175,14 +210,14 @@ enum CollectionOrderField {
     TOTAL_VOLUME
 
     """
-    Order by biggest gains.
+    Order by market cap gain.
     """
-    BIGGEST_GAINS
+    MARKET_CAP_GAIN
 
     """
-    Order by biggest losses.
+    Order by number of sales.
     """
-    BIGGEST_LOSSES
+    SALES
 
     """
     Order by daily volume.
@@ -233,6 +268,16 @@ type NFT {
     Rarity score for the NFT.
     """
     rarity: Float!
+
+    """
+    Trading price for this NFT.
+    """
+    trading_price: Float!
+
+    """
+    All time average-price for this NFT.
+    """
+    average_price: Float!
 
     """
     Traits contains a list of attributes of the NFT.


### PR DESCRIPTION
This PR extends the GraphQL schema with some aggregated stats for collections, marketplaces and NFTs.

These stats are retrieved from the Aggregation API.

- [x] Rebase this PR after queued PRs are reviewed and merged
- [x] Retested at that point to verify that it works with the updated schema