### PR TITLE
Switch to a much more performant market cap query

### DIFF
--- a/aggregate/stats/market_cap.go
+++ b/aggregate/stats/market_cap.go
@@ -10,24 +10,36 @@ import (
 // CollectionMarketCap returns the current market cap for the collection.
 func (s *Stats) CollectionMarketCap(address identifier.Address) (float64, error) {
 
-	// Latest price query will return prices per NFT ranked by freshness.
-	// Prices with the lowest rank (closer to 1) will be the most recent ones.
-	latestPriceQuery := s.db.
-		Table("sales").
-		Select("sales.*, row_number() OVER (PARTITION BY chain_id, collection_address, token_id ORDER BY emitted_at DESC) AS rank").
-		Where("chain_id = ?", address.ChainID).
-		Where("collection_address = ?", address.Address)
-
-	// Summarize query will return the sum of all of the freshest prices for
-	// NFTs in a collection. The query leverages the "latest price" query as a subquery
-	// for the prices.
-	sumQuery := s.db.
-		Table("( ? ) s", latestPriceQuery).
-		Select("SUM(trade_price) AS total").
-		Where("rank = 1")
+	query := s.db.Raw(
+		`WITH RECURSIVE cte AS (
+			(
+				SELECT token_id, trade_price
+				FROM sales
+				WHERE chain_id = ? and collection_address = ?
+				ORDER BY token_id, emitted_at DESC
+				LIMIT 1
+			)
+			UNION ALL
+			SELECT s.*
+			FROM cte c,
+			LATERAL (
+				SELECT token_id, trade_price
+				FROM sales
+				WHERE token_id > c.token_id AND chain_id = ? and collection_address = ?
+				ORDER BY token_id, emitted_at DESC
+				LIMIT 1
+			) s
+		)
+		SELECT SUM(trade_price) AS total
+		FROM cte`,
+		address.ChainID,
+		address.Address,
+		address.ChainID,
+		address.Address,
+	)
 
 	var marketCap datapoint.MarketCap
-	err := sumQuery.Take(&marketCap).Error
+	err := query.Scan(&marketCap).Error
 	if err != nil {
 		return 0, fmt.Errorf("could not retrieve market cap: %w", err)
 	}

--- a/aggregate/stats/market_cap_history.go
+++ b/aggregate/stats/market_cap_history.go
@@ -20,6 +20,9 @@ func (s *Stats) MarketplaceMarketCapHistory(addresses []identifier.Address, from
 
 func (s *Stats) marketCapHistory(collectionAddress *identifier.Address, marketplaceAddresses []identifier.Address, from time.Time, to time.Time) ([]datapoint.MarketCap, error) {
 
+	// TODO: Use a query with a recursive CTE for a huge performance improvement.
+	// See https://github.com/NFT-com/analytics/issues/40
+
 	// Latest price query will return prices per NFT ranked by freshness.
 	// Prices with the lowest rank (closer to 1) will be the most recent ones.
 	// The query has a date threshold to consider only prices up to a date.


### PR DESCRIPTION
This PR uses a different SQL query for calculating market cap for a collection. On my machine the difference in performance is huge, going from ~50 seconds using `ROW_NUMBER() OVER (PARTITION BY... ORDER BY emitted_at DESC)` variant to ~60 **miliseconds** using this variant.

Another variant was using a lateral join against the `nfts` table which was also super-fast, but cannot be used because, in the future, the events data will be in a separate database from the nft data, so any joining of those tables is out of the question.

Also just to note, queries using `DISTINCT ON` had similar performance to the  `ROW_NUMBER()` variant.

Relevant: https://github.com/NFT-com/analytics/issues/40