### PR TITLE
Fix queries for aggregation API

### DIFF
--- a/aggregate/stats/market_cap.go
+++ b/aggregate/stats/market_cap.go
@@ -63,7 +63,7 @@ func (s *Stats) CollectionBatchMarketCaps(addresses []identifier.Address) (map[i
 
 	sumQuery := s.db.
 		Table("( ? ) c", latestPriceQuery).
-		Select("SUM(trade_price) AS total, chain_id, LOWER(collection_address)").
+		Select("SUM(trade_price) AS total, chain_id, LOWER(collection_address) AS collection_address").
 		Where("c.rank = 1").
 		Group("chain_id, LOWER(collection_address)")
 

--- a/aggregate/stats/price.go
+++ b/aggregate/stats/price.go
@@ -38,7 +38,7 @@ func (s *Stats) NFTBatchPrices(nfts []identifier.NFT) (map[identifier.NFT]float6
 
 	selectFields := []string{
 		"chain_id",
-		"LOWER(collection_address)",
+		"LOWER(collection_address) AS collection_address",
 		"token_id",
 		"trade_price",
 		"row_number() OVER (PARTITION BY chain_id, LOWER(collection_address), token_id ORDER BY emitted_at DESC) AS rank",

--- a/aggregate/stats/volume.go
+++ b/aggregate/stats/volume.go
@@ -35,7 +35,7 @@ func (s *Stats) CollectionBatchVolumes(addresses []identifier.Address) (map[iden
 
 	query := s.db.
 		Table("sales").
-		Select("SUM(trade_price) AS total, chain_id, LOWER(collection_address)").
+		Select("SUM(trade_price) AS total, chain_id, LOWER(collection_address) AS collection_address").
 		Group("chain_id, LOWER(collection_address)")
 
 	filter := s.createCollectionFilter(addresses)


### PR DESCRIPTION
Use alias when using LOWER() in a SELECT. Otherwise the column containing the lowercased value is referenced as `lower` which messes up result unmarshalling