### PR TITLE
Use 'decimal.Decimal' instead of float64 for stats

### DIFF
--- a/aggregate/api/sales.go
+++ b/aggregate/api/sales.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shopspring/decimal"
 
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 )
@@ -27,7 +28,7 @@ func (a *API) CollectionSales(ctx echo.Context) error {
 
 	response := datapoint.Value{
 		ID:    id,
-		Value: float64(sales),
+		Value: decimal.NewFromInt(int64(sales)),
 	}
 
 	return ctx.JSON(http.StatusOK, response)
@@ -52,7 +53,7 @@ func (a *API) MarketplaceSales(ctx echo.Context) error {
 
 	response := datapoint.Value{
 		ID:    id,
-		Value: float64(sales),
+		Value: decimal.NewFromInt(int64(sales)),
 	}
 
 	return ctx.JSON(http.StatusOK, response)

--- a/aggregate/api/stats.go
+++ b/aggregate/api/stats.go
@@ -3,6 +3,8 @@ package api
 import (
 	"time"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 	"github.com/NFT-com/analytics/aggregate/models/identifier"
 )
@@ -10,11 +12,11 @@ import (
 type Stats interface {
 
 	// Collection statistics - current.
-	CollectionVolume(address identifier.Address) (float64, error)
-	CollectionMarketCap(address identifier.Address) (float64, error)
+	CollectionVolume(address identifier.Address) (decimal.Decimal, error)
+	CollectionMarketCap(address identifier.Address) (decimal.Decimal, error)
 	CollectionSales(address identifier.Address) (uint64, error)
-	CollectionBatchVolumes(addresses []identifier.Address) (map[identifier.Address]float64, error)
-	CollectionBatchMarketCaps(addresses []identifier.Address) (map[identifier.Address]float64, error)
+	CollectionBatchVolumes(addresses []identifier.Address) (map[identifier.Address]decimal.Decimal, error)
+	CollectionBatchMarketCaps(addresses []identifier.Address) (map[identifier.Address]decimal.Decimal, error)
 
 	// Collection statistics - history.
 	CollectionVolumeHistory(address identifier.Address, from time.Time, to time.Time) ([]datapoint.Volume, error)
@@ -25,8 +27,8 @@ type Stats interface {
 	CollectionSizeHistory(address identifier.Address, from time.Time, to time.Time) ([]datapoint.Count, error)
 
 	// Marketplace statistics - current.
-	MarketplaceVolume(addresses []identifier.Address) (float64, error)
-	MarketplaceMarketCap(addresses []identifier.Address) (float64, error)
+	MarketplaceVolume(addresses []identifier.Address) (decimal.Decimal, error)
+	MarketplaceMarketCap(addresses []identifier.Address) (decimal.Decimal, error)
 	MarketplaceSales(addresses []identifier.Address) (uint64, error)
 	MarketplaceUserCount(addresses []identifier.Address) (uint64, error)
 
@@ -37,8 +39,8 @@ type Stats interface {
 	MarketplaceUserCountHistory(addresses []identifier.Address, from time.Time, to time.Time) ([]datapoint.Users, error)
 
 	// NFT statistics - current.
-	NFTPrice(address identifier.NFT) (float64, error)
-	NFTBatchPrices(addresses []identifier.NFT) (map[identifier.NFT]float64, error)
+	NFTPrice(address identifier.NFT) (decimal.Decimal, error)
+	NFTBatchPrices(addresses []identifier.NFT) (map[identifier.NFT]decimal.Decimal, error)
 
 	// NFT statistics - history.
 	NFTPriceHistory(address identifier.NFT, from time.Time, to time.Time) ([]datapoint.Price, error)

--- a/aggregate/api/users.go
+++ b/aggregate/api/users.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"github.com/shopspring/decimal"
 
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 )
@@ -28,7 +29,7 @@ func (a *API) MarketplaceUsers(ctx echo.Context) error {
 
 	response := datapoint.Value{
 		ID:    id,
-		Value: float64(users),
+		Value: decimal.NewFromInt(int64(users)),
 	}
 
 	return ctx.JSON(http.StatusOK, response)

--- a/aggregate/models/datapoint/datapoint.go
+++ b/aggregate/models/datapoint/datapoint.go
@@ -2,24 +2,26 @@ package datapoint
 
 import (
 	"time"
+
+	"github.com/shopspring/decimal"
 )
 
 // Value represents the generic datatype for some stat.
 type Value struct {
-	ID    string  `json:"id,omitempty"`
-	Value float64 `json:"value,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Value decimal.Decimal `json:"value,omitempty"`
 }
 
 // Volume represents the trading volume for a given category (e.g. collection or a marketplace).
 type Volume struct {
-	Total float64    `json:"total" gorm:"column:total"`
-	Date  *time.Time `json:"date,omitempty" gorm:"column:date"`
+	Total decimal.Decimal `json:"total" gorm:"column:total"`
+	Date  *time.Time      `json:"date,omitempty" gorm:"column:date"`
 }
 
 // MarketCap represents the total market cap of a given entity (collection or a marketplace).
 type MarketCap struct {
-	Total float64    `json:"total" gorm:"column:total"`
-	Date  *time.Time `json:"date,omitempty" gorm:"column:date"`
+	Total decimal.Decimal `json:"total" gorm:"column:total"`
+	Date  *time.Time      `json:"date,omitempty" gorm:"column:date"`
 }
 
 // Sale represents the number of sales for a given category (e.g. collection or a marketplace).
@@ -32,15 +34,15 @@ type Sale struct {
 // `Start` and `End` values denote the time span over which the
 // minimum trading price is calculated.
 type Floor struct {
-	Floor float64 `json:"floor" gorm:"column:floor"`
-	Start string  `json:"start" gorm:"column:start_date"`
-	End   string  `json:"end" gorm:"column:end_date"`
+	Floor decimal.Decimal `json:"floor" gorm:"column:floor"`
+	Start string          `json:"start" gorm:"column:start_date"`
+	End   string          `json:"end" gorm:"column:end_date"`
 }
 
 // Average represents the average price of an NFT in a collection.
 type Average struct {
-	Average float64    `json:"average" gorm:"column:average"`
-	Date    *time.Time `json:"date,omitempty" gorm:"column:date"`
+	Average decimal.Decimal `json:"average" gorm:"column:average"`
+	Date    *time.Time      `json:"date,omitempty" gorm:"column:date"`
 }
 
 // Users represents the number of unique users on a marketplace.
@@ -53,8 +55,8 @@ type Users struct {
 // NOTE: This is the only data type that uses the actual time instead
 // of the date.
 type Price struct {
-	Price float64    `json:"price" gorm:"column:trade_price"`
-	Time  *time.Time `json:"emitted_at,omitempty" gorm:"column:emitted_at"`
+	Price decimal.Decimal `json:"price" gorm:"column:trade_price"`
+	Time  *time.Time      `json:"emitted_at,omitempty" gorm:"column:emitted_at"`
 }
 
 // Count represents the total number of NFTs in a collection.

--- a/aggregate/stats/market_cap.go
+++ b/aggregate/stats/market_cap.go
@@ -3,12 +3,14 @@ package stats
 import (
 	"fmt"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 	"github.com/NFT-com/analytics/aggregate/models/identifier"
 )
 
 // CollectionMarketCap returns the current market cap for the collection.
-func (s *Stats) CollectionMarketCap(address identifier.Address) (float64, error) {
+func (s *Stats) CollectionMarketCap(address identifier.Address) (decimal.Decimal, error) {
 
 	query := s.db.Raw(
 		`WITH RECURSIVE cte AS (
@@ -41,7 +43,7 @@ func (s *Stats) CollectionMarketCap(address identifier.Address) (float64, error)
 	var marketCap datapoint.MarketCap
 	err := query.Scan(&marketCap).Error
 	if err != nil {
-		return 0, fmt.Errorf("could not retrieve market cap: %w", err)
+		return decimal.NewFromInt(0), fmt.Errorf("could not retrieve market cap: %w", err)
 	}
 
 	return marketCap.Total, nil
@@ -49,7 +51,7 @@ func (s *Stats) CollectionMarketCap(address identifier.Address) (float64, error)
 
 // CollectionMarketCaps returns the current market cap for the list of collections.
 // Market caps are mapped to the lowercased collection contract address.
-func (s *Stats) CollectionBatchMarketCaps(addresses []identifier.Address) (map[identifier.Address]float64, error) {
+func (s *Stats) CollectionBatchMarketCaps(addresses []identifier.Address) (map[identifier.Address]decimal.Decimal, error) {
 
 	if len(addresses) == 0 {
 		return nil, fmt.Errorf("address list must be non-empty")
@@ -75,7 +77,7 @@ func (s *Stats) CollectionBatchMarketCaps(addresses []identifier.Address) (map[i
 	}
 
 	// Transform the list of market caps to a map.
-	capMap := make(map[identifier.Address]float64, len(caps))
+	capMap := make(map[identifier.Address]decimal.Decimal, len(caps))
 	for _, cap := range caps {
 
 		collection := identifier.Address{
@@ -90,7 +92,7 @@ func (s *Stats) CollectionBatchMarketCaps(addresses []identifier.Address) (map[i
 }
 
 // MarketplaceMarketCap returns the current market cap for the marketplace.
-func (s *Stats) MarketplaceMarketCap(addresses []identifier.Address) (float64, error) {
+func (s *Stats) MarketplaceMarketCap(addresses []identifier.Address) (decimal.Decimal, error) {
 
 	// Latest price query will return prices per NFT ranked by freshness.
 	// Prices with the lowest rank (closer to 1) will be the most recent ones.
@@ -112,7 +114,7 @@ func (s *Stats) MarketplaceMarketCap(addresses []identifier.Address) (float64, e
 	var marketCap datapoint.MarketCap
 	err := sumQuery.Take(&marketCap).Error
 	if err != nil {
-		return 0, fmt.Errorf("could not retrieve market cap: %w", err)
+		return decimal.NewFromInt(0), fmt.Errorf("could not retrieve market cap: %w", err)
 	}
 
 	return marketCap.Total, nil

--- a/aggregate/stats/model.go
+++ b/aggregate/stats/model.go
@@ -1,17 +1,21 @@
 package stats
 
+import (
+	"github.com/shopspring/decimal"
+)
+
 // batchPriceResult represents the result of the batch NFT price query.
 type batchPriceResult struct {
-	ChainID           uint    `gorm:"column:chain_id"`
-	CollectionAddress string  `gorm:"column:collection_address"`
-	TokenID           string  `gorm:"column:token_id"`
-	TradePrice        float64 `gorm:"column:trade_price"`
+	ChainID           uint            `gorm:"column:chain_id"`
+	CollectionAddress string          `gorm:"column:collection_address"`
+	TokenID           string          `gorm:"column:token_id"`
+	TradePrice        decimal.Decimal `gorm:"column:trade_price"`
 }
 
 // batchStatResult represents the result of the batch collection volume
 // and market cap queries.
 type batchStatResult struct {
-	ChainID           uint    `gorm:"column:chain_id"`
-	CollectionAddress string  `gorm:"column:collection_address"`
-	Total             float64 `gorm:"column:total"`
+	ChainID           uint            `gorm:"column:chain_id"`
+	CollectionAddress string          `gorm:"column:collection_address"`
+	Total             decimal.Decimal `gorm:"column:total"`
 }

--- a/aggregate/stats/price.go
+++ b/aggregate/stats/price.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 	"github.com/NFT-com/analytics/aggregate/models/identifier"
 )
 
 // NFTPrice returns the current NFT price for an NFT.
-func (s *Stats) NFTPrice(nft identifier.NFT) (float64, error) {
+func (s *Stats) NFTPrice(nft identifier.NFT) (decimal.Decimal, error) {
 
 	query := s.db.
 		Table("sales").
@@ -23,7 +25,7 @@ func (s *Stats) NFTPrice(nft identifier.NFT) (float64, error) {
 	var price datapoint.Price
 	err := query.Take(&price).Error
 	if err != nil {
-		return 0, fmt.Errorf("could not retrieve price: %w", err)
+		return decimal.NewFromInt(0), fmt.Errorf("could not retrieve price: %w", err)
 	}
 
 	return price.Price, nil
@@ -31,7 +33,7 @@ func (s *Stats) NFTPrice(nft identifier.NFT) (float64, error) {
 
 // NFTBatchPrice returns the list of prices for the specified NFTs.
 // Prices are mapped to the NFT identifier, with the collection contract address being lowercased.
-func (s *Stats) NFTBatchPrices(nfts []identifier.NFT) (map[identifier.NFT]float64, error) {
+func (s *Stats) NFTBatchPrices(nfts []identifier.NFT) (map[identifier.NFT]decimal.Decimal, error) {
 
 	if len(nfts) == 0 {
 		return nil, errors.New("id list must be non-empty")
@@ -65,7 +67,7 @@ func (s *Stats) NFTBatchPrices(nfts []identifier.NFT) (map[identifier.NFT]float6
 	}
 
 	// Transform the list of prices into a map, mapping the NFT identifier to the price point.
-	priceMap := make(map[identifier.NFT]float64, len(nfts))
+	priceMap := make(map[identifier.NFT]decimal.Decimal, len(nfts))
 	for _, price := range prices {
 
 		// Create the NFT identifier.

--- a/aggregate/stats/volume.go
+++ b/aggregate/stats/volume.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 	"github.com/NFT-com/analytics/aggregate/models/identifier"
 )
 
 // CollectionVolume returns the total value of all trades for this collection.
-func (s *Stats) CollectionVolume(address identifier.Address) (float64, error) {
+func (s *Stats) CollectionVolume(address identifier.Address) (decimal.Decimal, error) {
 
 	query := s.db.
 		Table("sales").
@@ -20,7 +22,7 @@ func (s *Stats) CollectionVolume(address identifier.Address) (float64, error) {
 	var volume datapoint.Volume
 	err := query.Take(&volume).Error
 	if err != nil {
-		return 0, fmt.Errorf("could not retrieve collection volume: %w", err)
+		return decimal.NewFromInt(0), fmt.Errorf("could not retrieve collection volume: %w", err)
 	}
 
 	return volume.Total, nil
@@ -28,7 +30,7 @@ func (s *Stats) CollectionVolume(address identifier.Address) (float64, error) {
 
 // CollectionBatchVolumes returns the list of volumes for each individual collection.
 // Volumes are mapped to the lowercased collection contract address.
-func (s *Stats) CollectionBatchVolumes(addresses []identifier.Address) (map[identifier.Address]float64, error) {
+func (s *Stats) CollectionBatchVolumes(addresses []identifier.Address) (map[identifier.Address]decimal.Decimal, error) {
 
 	if len(addresses) == 0 {
 		return nil, errors.New("id list must be non-empty")
@@ -49,7 +51,7 @@ func (s *Stats) CollectionBatchVolumes(addresses []identifier.Address) (map[iden
 	}
 
 	// Map the volumes to the collection identifier.
-	volumeMap := make(map[identifier.Address]float64, len(volumes))
+	volumeMap := make(map[identifier.Address]decimal.Decimal, len(volumes))
 	for _, volume := range volumes {
 
 		collection := identifier.Address{
@@ -64,7 +66,7 @@ func (s *Stats) CollectionBatchVolumes(addresses []identifier.Address) (map[iden
 }
 
 // MarketplaceVolume returns the total value of all trades for this marketplace.
-func (s *Stats) MarketplaceVolume(addresses []identifier.Address) (float64, error) {
+func (s *Stats) MarketplaceVolume(addresses []identifier.Address) (decimal.Decimal, error) {
 
 	query := s.db.
 		Table("sales").
@@ -76,7 +78,7 @@ func (s *Stats) MarketplaceVolume(addresses []identifier.Address) (float64, erro
 	var volume datapoint.Volume
 	err := query.Take(&volume).Error
 	if err != nil {
-		return 0, fmt.Errorf("could not retrieve marketplace volume: %w", err)
+		return decimal.NewFromInt(0), fmt.Errorf("could not retrieve marketplace volume: %w", err)
 	}
 
 	return volume.Total, nil

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/labstack/echo/v4 v4.7.2
 	github.com/rs/zerolog v1.26.1
+	github.com/shopspring/decimal v1.2.0
 	github.com/spf13/pflag v1.0.5
 	github.com/vektah/gqlparser/v2 v2.4.2
 	github.com/wei840222/gorm-zerolog v0.0.0-20210303025759-235c42bb33fa

--- a/graph/aggregate/request.go
+++ b/graph/aggregate/request.go
@@ -3,13 +3,15 @@ package aggregate
 import (
 	"fmt"
 
+	"github.com/shopspring/decimal"
+
 	"github.com/NFT-com/analytics/aggregate/models/api"
 	"github.com/NFT-com/analytics/aggregate/models/datapoint"
 	"github.com/NFT-com/analytics/graph/aggregate/http"
 )
 
 // executeBatchRequest executes a generic POST request to retrieve stats for a list of IDS.
-func (c *Client) executeBatchRequest(ids []string, address string) (map[string]float64, error) {
+func (c *Client) executeBatchRequest(ids []string, address string) (map[string]decimal.Decimal, error) {
 
 	// Create the batch price request.
 	req := api.BatchRequest{
@@ -24,7 +26,7 @@ func (c *Client) executeBatchRequest(ids []string, address string) (map[string]f
 	}
 
 	// Create the output.
-	out := make(map[string]float64)
+	out := make(map[string]decimal.Decimal)
 	for _, price := range res.Data {
 		out[price.ID] = price.Value
 	}
@@ -33,17 +35,17 @@ func (c *Client) executeBatchRequest(ids []string, address string) (map[string]f
 }
 
 // executeRequest executes a generic GET request to retrieve stat for a single ID.
-func (c *Client) executeRequest(id string, address string) (float64, error) {
+func (c *Client) executeRequest(id string, address string) (decimal.Decimal, error) {
 
 	var res datapoint.Value
 	err := http.GET(address, &res)
 	if err != nil {
-		return 0, fmt.Errorf("request failed: %w", err)
+		return decimal.NewFromInt(0), fmt.Errorf("request failed: %w", err)
 	}
 
 	// Verify that we have the correct record.
 	if res.ID != id {
-		return 0, fmt.Errorf("unexpected record returned (want: %v, have: %v): %w", id, res.ID, err)
+		return decimal.NewFromInt(0), fmt.Errorf("unexpected record returned (want: %v, have: %v): %w", id, res.ID, err)
 	}
 
 	return res.Value, nil

--- a/graph/aggregate/stats.go
+++ b/graph/aggregate/stats.go
@@ -2,10 +2,12 @@ package aggregate
 
 import (
 	"fmt"
+
+	"github.com/shopspring/decimal"
 )
 
 // Prices retrieves the prices for the specified NFTs.
-func (c *Client) Prices(ids []string) (map[string]float64, error) {
+func (c *Client) Prices(ids []string) (map[string]decimal.Decimal, error) {
 
 	c.log.Debug().Strs("ids", ids).Msg("requesting NFT prices")
 
@@ -14,7 +16,7 @@ func (c *Client) Prices(ids []string) (map[string]float64, error) {
 }
 
 // AveragePrice retrieves the average price for the specified NFT.
-func (c *Client) AveragePrice(id string) (float64, error) {
+func (c *Client) AveragePrice(id string) (decimal.Decimal, error) {
 
 	c.log.Debug().Str("id", id).Msg("requesting NFT average price")
 
@@ -24,7 +26,7 @@ func (c *Client) AveragePrice(id string) (float64, error) {
 }
 
 // CollectionVolumes retrieves the volumes for the specified collections.
-func (c *Client) CollectionVolumes(ids []string) (map[string]float64, error) {
+func (c *Client) CollectionVolumes(ids []string) (map[string]decimal.Decimal, error) {
 
 	c.log.Debug().Strs("ids", ids).Msg("requesting collection volumes")
 
@@ -33,7 +35,7 @@ func (c *Client) CollectionVolumes(ids []string) (map[string]float64, error) {
 }
 
 // CollectionMarketCaps retrieves the market caps for the specified collections.
-func (c *Client) CollectionMarketCaps(ids []string) (map[string]float64, error) {
+func (c *Client) CollectionMarketCaps(ids []string) (map[string]decimal.Decimal, error) {
 
 	c.log.Debug().Strs("ids", ids).Msg("requesting collection market caps")
 
@@ -42,7 +44,7 @@ func (c *Client) CollectionMarketCaps(ids []string) (map[string]float64, error) 
 }
 
 // CollectionSales retrieves the sale count for the specified collection.
-func (c *Client) CollectionSales(id string) (float64, error) {
+func (c *Client) CollectionSales(id string) (decimal.Decimal, error) {
 
 	c.log.Debug().Str("id", id).Msg("requesting collection sale count")
 
@@ -52,7 +54,7 @@ func (c *Client) CollectionSales(id string) (float64, error) {
 }
 
 // MarketplaceVolume retrieves the volume for the specified marketplace.
-func (c *Client) MarketplaceVolume(id string) (float64, error) {
+func (c *Client) MarketplaceVolume(id string) (decimal.Decimal, error) {
 
 	c.log.Debug().Str("id", id).Msg("requesting marketplace volume")
 
@@ -62,7 +64,7 @@ func (c *Client) MarketplaceVolume(id string) (float64, error) {
 }
 
 // MarketplaceMarketCap retrieves the market cap for the specified marketplace.
-func (c *Client) MarketplaceMarketCap(id string) (float64, error) {
+func (c *Client) MarketplaceMarketCap(id string) (decimal.Decimal, error) {
 
 	c.log.Debug().Str("id", id).Msg("requesting marketplace market cap")
 
@@ -72,7 +74,7 @@ func (c *Client) MarketplaceMarketCap(id string) (float64, error) {
 }
 
 // MarketplaceSales retrieves the sale count for the specified marketplace.
-func (c *Client) MarketplaceSales(id string) (float64, error) {
+func (c *Client) MarketplaceSales(id string) (decimal.Decimal, error) {
 
 	c.log.Debug().Str("id", id).Msg("requesting marketplace sale count")
 
@@ -82,7 +84,7 @@ func (c *Client) MarketplaceSales(id string) (float64, error) {
 }
 
 // MarketplaceUsers retrieves the user count for the specified marketplace.
-func (c *Client) MarketplaceUsers(id string) (float64, error) {
+func (c *Client) MarketplaceUsers(id string) (decimal.Decimal, error) {
 
 	c.log.Debug().Str("id", id).Msg("requesting marketplace user count")
 

--- a/graph/api/collection_details.go
+++ b/graph/api/collection_details.go
@@ -46,7 +46,7 @@ func (s *Server) expandCollectionStats(query *query.Collection, collection *api.
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get collection volume: %w", err))
 		}
 
-		collection.Volume = volumes[collection.ID]
+		collection.Volume, _ = volumes[collection.ID].Float64()
 	}
 
 	// Get market cap from the aggregation API.
@@ -56,7 +56,7 @@ func (s *Server) expandCollectionStats(query *query.Collection, collection *api.
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get collection market cap: %w", err))
 		}
 
-		collection.MarketCap = caps[collection.ID]
+		collection.MarketCap, _ = caps[collection.ID].Float64()
 	}
 
 	// Get sale count from the aggregation API.
@@ -66,7 +66,7 @@ func (s *Server) expandCollectionStats(query *query.Collection, collection *api.
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get collection sales: %w", err))
 		}
 
-		collection.Sales = uint64(sales)
+		collection.Sales = sales.BigInt().Uint64()
 	}
 
 	return multiErr

--- a/graph/api/marketplace_stats.go
+++ b/graph/api/marketplace_stats.go
@@ -21,7 +21,7 @@ func (s *Server) expandMarketplaceStats(query *query.Marketplace, marketplace *a
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace volume: %w", err))
 		}
 
-		marketplace.Volume = volume
+		marketplace.Volume, _ = volume.Float64()
 	}
 
 	// Get market cap from the aggregation API.
@@ -31,7 +31,7 @@ func (s *Server) expandMarketplaceStats(query *query.Marketplace, marketplace *a
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace market cap: %w", err))
 		}
 
-		marketplace.MarketCap = cap
+		marketplace.MarketCap, _ = cap.Float64()
 	}
 
 	// Get sale count from the aggregation API.
@@ -41,7 +41,7 @@ func (s *Server) expandMarketplaceStats(query *query.Marketplace, marketplace *a
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace sales: %w", err))
 		}
 
-		marketplace.Sales = uint64(sales)
+		marketplace.Sales = sales.BigInt().Uint64()
 	}
 
 	// Get user count from the aggregation API.
@@ -51,7 +51,7 @@ func (s *Server) expandMarketplaceStats(query *query.Marketplace, marketplace *a
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not get marketplace users: %w", err))
 		}
 
-		marketplace.Users = uint64(users)
+		marketplace.Users = users.BigInt().Uint64()
 	}
 
 	return multiErr

--- a/graph/api/prices.go
+++ b/graph/api/prices.go
@@ -20,7 +20,7 @@ func (s *Server) getNFTStats(query *query.NFT, nft *api.NFT) error {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not retrieve price for NFT: %w", err))
 		}
 
-		nft.TradingPrice = prices[nft.ID]
+		nft.TradingPrice, _ = prices[nft.ID].Float64()
 	}
 
 	// Retrieve NFT average price from the aggregation API.
@@ -30,7 +30,7 @@ func (s *Server) getNFTStats(query *query.NFT, nft *api.NFT) error {
 			multiErr = multierror.Append(multiErr, fmt.Errorf("could not retrieve average price for NFT: %w", err))
 		}
 
-		nft.AveragePrice = average
+		nft.AveragePrice, _ = average.Float64()
 	}
 
 	return multiErr

--- a/graph/api/stats.go
+++ b/graph/api/stats.go
@@ -1,18 +1,22 @@
 package api
 
+import (
+	"github.com/shopspring/decimal"
+)
+
 // TODO: Add batch requests for all stats.
 // See https://github.com/NFT-com/analytics/issues/39.
 
 type Stats interface {
-	Prices(nftIDs []string) (map[string]float64, error)
-	AveragePrice(nftID string) (float64, error)
+	Prices(nftIDs []string) (map[string]decimal.Decimal, error)
+	AveragePrice(nftID string) (decimal.Decimal, error)
 
-	CollectionVolumes(collectionIDs []string) (map[string]float64, error)
-	CollectionMarketCaps(collectionIDs []string) (map[string]float64, error)
-	CollectionSales(collectionID string) (float64, error)
+	CollectionVolumes(collectionIDs []string) (map[string]decimal.Decimal, error)
+	CollectionMarketCaps(collectionIDs []string) (map[string]decimal.Decimal, error)
+	CollectionSales(collectionID string) (decimal.Decimal, error)
 
-	MarketplaceVolume(marketplaceID string) (float64, error)
-	MarketplaceMarketCap(marketplaceID string) (float64, error)
-	MarketplaceSales(marketplaceID string) (float64, error)
-	MarketplaceUsers(marketplaceID string) (float64, error)
+	MarketplaceVolume(marketplaceID string) (decimal.Decimal, error)
+	MarketplaceMarketCap(marketplaceID string) (decimal.Decimal, error)
+	MarketplaceSales(marketplaceID string) (decimal.Decimal, error)
+	MarketplaceUsers(marketplaceID string) (decimal.Decimal, error)
 }


### PR DESCRIPTION
This PR changes all the aggregated stats to use [decimal.Decimal ](https://github.com/shopspring/decimal) type instead of `float64` for the stats, since float64 is not precise enough, and the decimal type has both the SQL Scanner/Valuer interfaces, as well as JSON [un]marshalling properly implemented.

At the moment, the GraphQL schema is not changed and the decimal type is cast to `float64`/`uint64` as needed.

⚠️ Yet to be tested