### PR TITLE
Make Event and Aggregation APIs return 404s when records are not found

### DIFF
--- a/aggregate/api/errors.go
+++ b/aggregate/api/errors.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 var (
@@ -22,5 +23,9 @@ func bindError(err error) *echo.HTTPError {
 // apiError is used when something went wrong during request processing - e.g. something couldn't
 // be retrieved from the database.
 func apiError(err error) *echo.HTTPError {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+
 	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 }

--- a/events/api/errors.go
+++ b/events/api/errors.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 // TODO: Improve error handling - some errors need not be relayed to the user.
@@ -17,5 +19,9 @@ func bindError(err error) *echo.HTTPError {
 // apiError is used when something went wrong during request processing - e.g. the events couldn't
 // be retrieved from the database.
 func apiError(err error) *echo.HTTPError {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return echo.NewHTTPError(http.StatusNotFound, err.Error())
+	}
+
 	return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 }


### PR DESCRIPTION
## Goal of this PR

### Description

This PR makes the Events and Aggregation APIs respond with 404 when a record is missing. This is done easily by checking for `gorm.ErrRecordNotFound` within the wrapped error at the API server level.

Of course, there is no notion of returning 404 in the GraphQL API, so there is no change to be made there.

### Related Issue

Fixes #48 

## Checklist

### Does this PR Change GraphQL Schema

No

### Does this PR change Aggregation API Interface

No

### Does this PR Change Events API Interface

No

### Does this PR change the CLI usage of an executable

No

### Does this PR change SQL queries

No

### Misc

- [x] SQL data models are up-to-date with the [SQL schema](https://github.com/NFT-com/indexer/tree/master/sql)
- [x] Any deferred tasks have corresponding GitHub issues created
- [x] PR is against the correct branch
- [x] PR is labelled appropriately
- [x] PR is linked to an issue
